### PR TITLE
Kadai_31 「申し込み状況の機能」まで完了

### DIFF
--- a/src/main/java/com/example/S7/ApplicationStatus.java
+++ b/src/main/java/com/example/S7/ApplicationStatus.java
@@ -1,0 +1,15 @@
+package com.example.S7;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class ApplicationStatus {
+
+  private int id;
+  private int studentId;
+  private int courseId;
+  private String status; //仮申込、本申込、受講中、受講終了
+}

--- a/src/main/java/com/example/S7/domain/StudentDetail.java
+++ b/src/main/java/com/example/S7/domain/StudentDetail.java
@@ -33,6 +33,16 @@ public class StudentDetail {
    */
   @Valid
   private List<StudentCourse> studentCourseList;
+
+  /**
+   * 申込状況を受け取る＆返すためのステータスです。
+   */
+  private String status; // 申込状況（仮申込・本申込・受講中・受講終了）
+
+  public StudentDetail(Student student, List<StudentCourse> studentCourseList) {
+    this.student = student;
+    this.studentCourseList = studentCourseList;
+  }
 }
 
 

--- a/src/main/java/com/example/S7/repository/ApplicationStatusMapper.java
+++ b/src/main/java/com/example/S7/repository/ApplicationStatusMapper.java
@@ -1,0 +1,20 @@
+package com.example.S7.repository;
+
+import com.example.S7.ApplicationStatus;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface ApplicationStatusMapper {
+
+  ApplicationStatus findStatus(@Param("studentId") int studentId, @Param("courseId") int courseId);
+
+  List<ApplicationStatus> findAll();
+
+  void insert(ApplicationStatus status);
+
+  void update(ApplicationStatus status);
+
+}

--- a/src/main/java/com/example/S7/service/StudentService.java
+++ b/src/main/java/com/example/S7/service/StudentService.java
@@ -1,10 +1,12 @@
 package com.example.S7.service;
 
+import com.example.S7.ApplicationStatus;
 import com.example.S7.controller.converter.StudentConverter;
 import com.example.S7.data.Student;
 import com.example.S7.data.StudentCourse;
 import com.example.S7.domain.StudentDetail;
 import com.example.S7.exception.StudentNotFoundException;
+import com.example.S7.repository.ApplicationStatusMapper;
 import com.example.S7.repository.StudentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -17,13 +19,16 @@ import java.util.List;
 @Service
 public class StudentService {
 
+  private final ApplicationStatusMapper statusMapper;
   private final StudentRepository repository;
   private final StudentConverter converter;
 
   @Autowired
-  public StudentService(StudentRepository repository, StudentConverter converter) {
+  public StudentService(StudentRepository repository, StudentConverter converter,
+      ApplicationStatusMapper statusMapper) {
     this.repository = repository;
     this.converter = converter;
+    this.statusMapper = statusMapper;
   }
 
   /**
@@ -45,7 +50,7 @@ public class StudentService {
   }
 
   /**
-   * 学生とコースを同時に登録します。
+   * 学生とコース、申し込み状況を同時に登録します。
    */
   @Transactional
   public StudentDetail insertStudentWithCourse(StudentDetail studentDetail) {
@@ -57,6 +62,16 @@ public class StudentService {
       StudentCourse course = courses.get(0);
       course.setStudentId(student.getStudentId());
       repository.insertCourse(course);
+
+      //申込状況の登録
+      String statusValue = studentDetail.getStatus();
+      if (statusValue != null && !statusValue.isEmpty()) {
+        ApplicationStatus status = new ApplicationStatus();
+        status.setStudentId(student.getStudentId());
+        status.setCourseId(course.getCourseId());
+        status.setStatus(studentDetail.getStatus());
+        statusMapper.insert(status);
+      }
     }
 
     return studentDetail;
@@ -68,7 +83,21 @@ public class StudentService {
   public StudentDetail findStudentDetailById(int studentId) {
     Student student = repository.findStudentById(studentId);
     List<StudentCourse> courses = repository.findCoursesByStudentId(studentId);
-    return new StudentDetail(student, courses);
+
+    String statusValue = null;
+    if (!courses.isEmpty()) {
+      int courseId = courses.get(0).getCourseId();
+      ApplicationStatus status = statusMapper.findStatus(studentId, courseId);
+      if (status != null) {
+        statusValue = status.getStatus();
+      }
+    }
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(courses);
+    detail.setStatus(statusValue);
+    return detail;
   }
 
   /**
@@ -83,6 +112,17 @@ public class StudentService {
     if (courses != null && !courses.isEmpty()) {
       StudentCourse course = courses.get(0);
       repository.updateCourse(course);
+
+      //ステータスの更新
+      ApplicationStatus status = statusMapper.findStatus(
+          student.getStudentId(),
+          course.getCourseId()
+      );
+
+      if (status != null) {
+        status.setStatus(studentDetail.getStatus());
+        statusMapper.update(status);
+      }
     }
   }
 
@@ -97,17 +137,8 @@ public class StudentService {
     return student;
   }
 
-
-  /**
-   * 学生に紐づくコース情報を1件取得します。
-   */
   public StudentCourse findCourseByStudentId(int studentId) {
     return repository.findCourseByStudentId(studentId);
   }
 
 }
-
-//リファクタリング箇所
-//insertStudentWithCourseでinsertStudentを呼び出すようにしてControllerで両方呼んでいたのをサービス側で1つにまとめてみました。
-
-//private finalを使いました。コンストラクタで注入されるフィールドは基本的に変更しないそうなので

--- a/src/main/resources/mapper/ApplicationStatusMapper.html
+++ b/src/main/resources/mapper/ApplicationStatusMapper.html
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.example.S7.repository.ApplicationStatusMapper">
+
+  <select id="findStatus" resultType="com.example.S7.data.ApplicationStatus">
+    SElECT * FROM application_statuses
+    WHERE student_id =#{studentId} AND course_id = #{courseId}
+  </select>
+
+  <select id="findAll" resultType="com.example.S7.data.ApplicationStatus">
+    SELECT * FROM application_statuses
+  </select>
+
+  <insert id="insert">
+    INSERT INTO application_statuses(student_id,course_id,status)
+    VALUES (#{studentId},#{courseId},#{status})
+  </insert>
+
+  <update id="update">
+    UPDATE application_statuses
+    SET status = #{status}
+    WHERE student_id = #{studentId} AND course_id = #{courseId}
+  </update>
+</mapper>

--- a/src/test/java/com/example/S7/service/StudentServiceTest.java
+++ b/src/test/java/com/example/S7/service/StudentServiceTest.java
@@ -1,13 +1,17 @@
 package com.example.S7.service;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.example.S7.ApplicationStatus;
 import com.example.S7.controller.converter.StudentConverter;
 import com.example.S7.data.Student;
 import com.example.S7.data.StudentCourse;
 import com.example.S7.domain.StudentDetail;
 import com.example.S7.exception.StudentNotFoundException;
+import com.example.S7.repository.ApplicationStatusMapper;
 import com.example.S7.repository.StudentRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,9 +34,13 @@ class StudentServiceTest {
 
   private StudentService sut;
 
+  @Mock
+  private ApplicationStatusMapper statusMapper;
+
+
   @BeforeEach
   void before() {
-    sut = new StudentService(repository, converter);
+    sut = new StudentService(repository, converter, statusMapper);
   }
 
   @Test
@@ -42,8 +50,8 @@ class StudentServiceTest {
     List<Student> studentList = new ArrayList<>();
     List<StudentCourse> studentCourseList = new ArrayList<>();
 
-    Mockito.when(repository.search()).thenReturn(studentList);
-    Mockito.when(repository.getAllStudentsCourses()).thenReturn(studentCourseList);
+    when(repository.search()).thenReturn(studentList);
+    when(repository.getAllStudentsCourses()).thenReturn(studentCourseList);
 
     //実行
     List<StudentDetail> actual = sut.searchStudentList();
@@ -69,7 +77,7 @@ class StudentServiceTest {
   @Test
   void insertStudentWithCourse_学生とコースを登録できること() {
     Student student = new Student();
-    student.setStudentId("1");
+    student.setStudentId(1);
     StudentCourse course = new StudentCourse();
     List<StudentCourse> courseList = List.of(course);
     StudentDetail detail = new StudentDetail(student, courseList);
@@ -87,8 +95,8 @@ class StudentServiceTest {
     Student student = new Student();
     List<StudentCourse> courseList = List.of(new StudentCourse());
 
-    Mockito.when(repository.findStudentById(1)).thenReturn(student);
-    Mockito.when(repository.findCoursesByStudentId(1)).thenReturn(courseList);
+    when(repository.findStudentById(1)).thenReturn(student);
+    when(repository.findCoursesByStudentId(1)).thenReturn(courseList);
 
     StudentDetail result = sut.findStudentDetailById(1);
 
@@ -100,7 +108,7 @@ class StudentServiceTest {
   void findStudentById_存在する場合はそのまま返ってくる() {
     Student student = new Student();
 
-    Mockito.when(repository.findStudentById(1)).thenReturn(student);
+    when(repository.findStudentById(1)).thenReturn(student);
 
     Assertions.assertEquals(student, sut.findStudentById(1));
   }
@@ -108,7 +116,7 @@ class StudentServiceTest {
   @Test
   void findStudentById_存在しない場合は例外がスローされる() {
 
-    Mockito.when(repository.findStudentById(1)).thenReturn(null);
+    when(repository.findStudentById(1)).thenReturn(null);
 
     Assertions.assertThrows(StudentNotFoundException.class, () -> sut.findStudentById(1));
   }
@@ -130,8 +138,121 @@ class StudentServiceTest {
   void findCourseByStudentId_正しいコース情報が返ってくる() {
     StudentCourse course = new StudentCourse();
 
-    Mockito.when(repository.findCourseByStudentId(1)).thenReturn(course);
+    when(repository.findCourseByStudentId(1)).thenReturn(course);
 
     Assertions.assertEquals(course, sut.findCourseByStudentId(1));
+  }
+
+  @Test
+  void 申し込みの状況が登録されること() {
+    Student student = new Student();
+    student.setStudentId(777);
+
+    StudentCourse course = new StudentCourse();
+    course.setCourseId(888);
+    List<StudentCourse> courseList = List.of(course);
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(courseList);
+    detail.setStatus("仮申込");
+
+    //リポジトリをセット
+    when(repository.insertStudent(student)).thenReturn(1); // ← int戻り値を設定
+    doNothing().when(repository).insertCourse(course);
+
+    sut.insertStudentWithCourse(detail);
+
+    verify(statusMapper).insert(Mockito.argThat(status ->
+        status.getStudentId() == 777 &&
+            status.getCourseId() == 888 &&
+            status.getStatus().equals("仮申込")
+    ));
+  }
+
+  @Test
+  void 申し込み状況が更新されること() {
+
+    Student student = new Student();
+    student.setStudentId(222);
+
+    StudentCourse course = new StudentCourse();
+    course.setCourseId(333);
+    List<StudentCourse> courseList = List.of(course);
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(courseList);
+    detail.setStatus("受講中");
+
+    ApplicationStatus existingStatus = new ApplicationStatus();
+    existingStatus.setStudentId(222);
+    existingStatus.setCourseId(333);
+    existingStatus.setStatus("仮申込");
+
+    //モックの戻り値
+    when(statusMapper.findStatus(222, 333)).thenReturn(existingStatus);
+
+    sut.updateStudentWithCourse(detail);
+
+    verify(statusMapper).update(Mockito.argThat(status ->
+        status.getStudentId() == 222 &&
+            status.getCourseId() == 333 &&
+            status.getStatus().equals("受講中")));
+  }
+
+  //異常系テスト
+  @Test
+  void statusがnull状態なら登録されないこと() {
+    Student student = new Student();
+    student.setStudentId(999);
+
+    StudentCourse course = new StudentCourse();
+    course.setCourseId(888);
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(List.of(course));
+    detail.setStatus(null);
+
+    sut.insertStudentWithCourse(detail);
+
+    verify(statusMapper, Mockito.never()).insert(Mockito.any());
+  }
+
+  @Test
+  void courseListが空ならstatus登録されないこと() {
+    Student student = new Student();
+    student.setStudentId(999);
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(new ArrayList<>());//空のリストをいれる
+    detail.setStatus("仮申込");
+
+    sut.insertStudentWithCourse(detail);
+
+    verify(statusMapper, Mockito.never()).insert(Mockito.any());
+  }
+
+  @Test
+  void ステータスが空なら更新しないこと() {
+    Student student = new Student();
+    student.setStudentId(111);
+
+    StudentCourse course = new StudentCourse();
+    course.setCourseId(222);
+
+    StudentDetail detail = new StudentDetail();
+    detail.setStudent(student);
+    detail.setStudentCourseList(List.of(course));
+    detail.setStatus("受講終了");
+
+    //findStatusがnullを返す＝ステータスが空
+    Mockito.when(statusMapper.findStatus(111, 222)).thenReturn(null);
+
+    sut.updateStudentWithCourse(detail);
+
+    verify(statusMapper, Mockito.never()).update(Mockito.any());
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,3 +7,4 @@ spring.datasource.password=
 spring.h2.console.enabled=true
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:/mapper/*.xml
+mybatis.type-aliases-package: com.example.S7.data


### PR DESCRIPTION
申込状況（ステータス）を管理する機能をアプリケーションに追加して、登録・更新・検索できるようにしてみました。

➀ 申込状況（status）の管理
新しいテーブル application_statuses を作成。
・ student_id, course_id, status（仮申込・本申込・受講中・受講終了）

② StudentDetail にステータスを追加。
・画面とサーバ間でやり取り可能に

③ステータス登録・更新の実装。
・insertStudentWithCourse()にステータスがある場合 insert するように

・updateStudentWithCourse()にステータスが存在すれば update するように

④Mapperの追加。
・ApplicationStatusMapper.java / xml を作成してSQLで insert / update / find を実装しました。


 正常系テスト
ステータスが正しく登録と更新がされることをテストをしてみました。

 異常系テスト
➀ステータスが null や空のコースリスト時 に登録と更新を行わないテスト

②status が存在しない場合に更新しないことをテストしてみました。



